### PR TITLE
Globals::moduleName fix

### DIFF
--- a/memcury.h
+++ b/memcury.h
@@ -232,7 +232,7 @@ namespace Memcury
     {
         constexpr const bool bLogging = true;
 
-        static const char* moduleName = nullptr;
+        inline const char* moduleName = nullptr;
     }
 
     namespace ASM


### PR DESCRIPTION
Sometimes this cant be read for some reason but changing it from static to inline seems to fix things.