### PR TITLE
feat(FindStringRef): impl find_first

### DIFF
--- a/memcury.h
+++ b/memcury.h
@@ -748,7 +748,7 @@ namespace Memcury
 
         // Supports wide and normal strings both std and pointers
         template <typename T = const wchar_t*>
-        static auto FindStringRef(T string) -> Scanner
+        static auto FindStringRef(T string, bool find_first = false) -> Scanner
         {
             PE::Address add { nullptr };
 
@@ -788,6 +788,8 @@ namespace Memcury
                                 if (leaT == string)
                                 {
                                     add = PE::Address(&scanBytes[i]);
+                                    if(find_first)
+                                        break;
                                 }
                             }
                             else
@@ -799,6 +801,8 @@ namespace Memcury
                                     if (wcscmp(string, lea) == 0)
                                     {
                                         add = PE::Address(&scanBytes[i]);
+                                        if(find_first)
+                                            break;
                                     }
                                 }
                                 else
@@ -806,6 +810,8 @@ namespace Memcury
                                     if (strcmp(string, lea) == 0)
                                     {
                                         add = PE::Address(&scanBytes[i]);
+                                        if(find_first)
+                                            break;
                                     }
                                 }
                             }


### PR DESCRIPTION
This PR implements a new parameter for FindStringRef that returns once it finds a reference.

The parameter find_first is set to false by default to ensure backward compatibility.